### PR TITLE
Add Dockerfile and Workflow

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: For which PMD version the docker image should be created?
+        description: For which PMD version the docker image should be created, e.g. 7.12.0?
         required: true
         type: string
       tags:
-        description: Comma separated list of tags to be pushed, e.g. "pmdcode/pmd:latest,pmdcode/pmd:x.y.z,pmdcode/pmd:x.y,pmdcode/pmd:x"
+        description: Comma separated list of tags to be pushed, e.g. "latest,x.y.z,x.y,x"
         required: true
         type: string
 
@@ -26,21 +26,53 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        # https://github.com/docker/login-action/releases/tag/v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Log in to the Container registry
+        # https://github.com/docker/login-action/releases/tag/v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create tags list
+        id: meta
+        env:
+          TAGS: ${{ inputs.tags }}
+        shell: bash
+        run: |
+          IFS="," read -ra TAGSARRAY <<< "$TAGS"
+          all_tags=""
+          for tag in "${TAGSARRAY[@]}"; do
+            all_tags="${all_tags}docker.io/pmdcode/pmd:$tag,ghcr.io/pmd/docker:$tag,"
+          done
+          # remove trailing comma
+          all_tags="${all_tags%,}"
+          echo "tags=${all_tags}" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -uIs)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker images
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        # https://github.com/docker/build-push-action/releases/tag/v6.15.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
           file: ./Dockerfile
           build-args: |
             PMD_VERSION=${{ inputs.version }}
           push: true
-          tags: ${{ inputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=PMD Docker
+            org.opencontainers.image.url=https://github.com/pmd/docker
+            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.created=${{ inputs.created }}
+            org.opencontainers.image.licenses=BSD-3-Clause
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,0 +1,50 @@
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: For which PMD version the docker image should be created?
+        required: true
+        type: string
+      tags:
+        description: Comma separated list of tags to be pushed, e.g. "pmdcode/pmd:latest,pmdcode/pmd:x.y.z,pmdcode/pmd:x.y,pmdcode/pmd:x"
+        required: true
+        type: string
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            PMD_VERSION=${{ inputs.version }}
+          push: true
+          tags: ${{ inputs.tags }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/pmdcode/pmd
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# https://docs.docker.com/reference/dockerfile/
+
+# SPDX-License-Identifier: BSD-3-Clause
+
+ARG PMD_VERSION
+ARG JAVA_VERSION=21
+
+# https://hub.docker.com/_/eclipse-temurin
+FROM eclipse-temurin:${JAVA_VERSION}-alpine
+
+ENV PMD_HOME=/opt/pmd
+ENV PATH=${PMD_HOME}/bin:${PATH}
+
+# bring global args into scope
+ARG PMD_VERSION
+
+RUN set -eux; \
+    apk add --no-cache \
+        # currently needed to run PMD, until https://github.com/pmd/pmd/pull/5623
+        bash \
+    ; \
+    rm -rf /var/cache/apk/*
+
+RUN set -eux; \
+    wget -O /pmd-dist-${PMD_VERSION}-bin.zip https://github.com/pmd/pmd/releases/download/pmd_releases%2F${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip; \
+    wget -O /pmd-dist-${PMD_VERSION}-bin.zip.asc https://github.com/pmd/pmd/releases/download/pmd_releases%2F${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip.asc; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    # gpg: key A0B5CA1A4E086838: public key "PMD Release Signing Key <releases@pmd-code.org>" imported
+    # See https://docs.pmd-code.org/latest/pmd_userdocs_signed_releases.html
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 1E046C19ED2873D8C08AF7B8A0632691B78E3422; \
+    gpg --batch --verify /pmd-dist-${PMD_VERSION}-bin.zip.asc /pmd-dist-${PMD_VERSION}-bin.zip; \
+    rm -rf "${GNUPGHOME}" /pmd-dist-${PMD_VERSION}-bin.zip.asc; \
+    unzip -d / /pmd-dist-${PMD_VERSION}-bin.zip; \
+    rm /pmd-dist-${PMD_VERSION}-bin.zip; \
+    mv /pmd-bin-${PMD_VERSION} ${PMD_HOME};
+
+
+RUN mkdir /src \
+    mkdir /custom-pmd-libs
+ENV CLASSPATH="/custom-pmd-libs/*"
+WORKDIR /src
+
+RUN set -eux; \
+    echo "Verifying install ..."; \
+    echo "pmd --version"; pmd --version; \
+    echo "Complete."
+
+ENTRYPOINT ["pmd"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# PMD Docker
+
+Provides [PMD](https://pmd.github.io) packaged in a Docker image ready to use. It uses the alpine linux
+flavor of [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin) as the basis.
+
+* **Maintained by:** [PMD](https://github.com/pmd/docker)
+* **Dockerfile:** https://github.com/pmd/docker/blob/main/Dockerfile
+
+## Quickstart
+
+```
+docker run --rm --tty -v $PWD:/src pmdcode/pmd:latest check -d . -R rulesets/java/quickstart.xml
+```
+
+## How to use this image
+
+### Verify it works
+
+This just displays the PMD version.
+
+```
+docker run --rm --tty pmdcode/pmd:latest --version
+```
+
+### Only using default rulesets
+
+In order to give access to the source code being analyzed, bind-mount the project source folder
+using `-v /path/to/project:/project`:
+
+```
+docker run --rm --tty -v /path/to/project:/project pmdcode/pmd:latest \
+    check -d /project/src/main/java -R rulesets/java/quickstart.xml
+```
+
+### Writing XML report into a file
+
+Since the bind-mount has write-access by default, you can use it as the output destination for a report file in XML format:
+
+```
+docker run --rm --tty -v /path/to/project:/project pmdcode/pmd:latest \
+    check -d /project/src/main/java -R rulesets/java/quickstart.xml -r /project/target/pmd-report.xml -f xml
+```
+
+### Use custom rulesets / rules
+
+If you use a custom ruleset or rule, you need to add this onto PMD's runtime classpath. By default, the container
+will pick-up any jar file that is in the folder `/custom-pmd-libs`. That means, you just need to add another
+bind-mount for this:
+
+```
+docker run --rm --tty -v /path/to/project:/project -v /path/to/custom-rule-jars:/custom-pmd-libs \
+    pmdcode/pmd:latest check -d /project/src/main/java -R rulesets/java/quickstart.xml
+```
+
+## How to build the docker image
+
+```
+PMD_VERSION=7.12.0; \
+export PMD_VERSION; \
+docker build --load \
+    --no-cache \
+    --progress=plain \
+    --build-arg PMD_VERSION=$PMD_VERSION \
+    --tag pmdcode/pmd:$PMD_VERSION \
+    --tag pmdcode/pmd:latest \
+    - < Dockerfile
+```
+


### PR DESCRIPTION
- Refs https://github.com/pmd/pmd/pull/5615
- Refs https://github.com/pmd/pmd/issues/5448

This includes now a GitHub Actions workflow, which can be triggered manually.
It should push the images to docker.io at https://hub.docker.com/r/pmdcode/pmd (docker.io/pmdcode/pmd:tag) and to GitHub's Container Registry at https://github.com/orgs/pmd/packages?repo_name=docker (ghcr.io/pmd/docker:tag).
